### PR TITLE
Get the skeleton for error handling down

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,13 @@
+# Adding a generic ignore to exclude any files without an extension
+*
+!*/
+!*.*
+!Makefile
+!LICENSE
+# Ignore binary files
+*.exe
+# Ignore Mac DS_Store
+.DS_Store
 tmp/*
+vendor/*/
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # VARS
-Vulnerability Assessment Reference System
+
+**V**ulnerability **A**ssessment **R**eference **S**ystem
+
+## Installing Dependencies
+
+We try to keep a stable development environment. Please use `govendor` to make sure you have the same version of our external packages.
+
+```bash
+#Install the govendor tool
+go get github.com/kardianos/govendor
+#Download the dependencies into the vendoring folder
+govendor sync
+```

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,80 @@
+package vars
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type errType int
+
+const (
+	noRowsInserted errType = iota
+	noRowsUpdated
+)
+
+var (
+	//ErrNoRowsInserted is used when there were not any rows inserted into the table
+	ErrNoRowsInserted = errors.New("No rows were inserted")
+	//ErrNoRowsUpdated is used when there were not any rows updated in the table
+	ErrNoRowsUpdated = errors.New("No rows were updated")
+	//ErrGenericVars is used when the error is too generic
+	ErrGenericVars = errors.New("Something went wrong")
+)
+
+//Err is an error that occured inside the vars package
+type Err struct {
+	parents []string
+	err     error
+}
+
+//Creates a new VARS error based on the type
+func newErr(errT errType, parents ...string) Err {
+	err := new(Err)
+	err.parents = parents
+	switch errT {
+	case noRowsInserted:
+		err.err = ErrNoRowsInserted
+	case noRowsUpdated:
+		err.err = ErrNoRowsUpdated
+	default:
+		err.err = ErrGenericVars
+	}
+	return *err
+}
+
+//Creates a new VARS error using the error given
+//If the error given was already a VARS error Prepend the parents and don't change the error
+func newErrFromErr(err error, parents ...string) Err {
+	if varsErr, ok := err.(Err); ok {
+		return Err{
+			parents: append(parents, varsErr.parents...),
+			err:     varsErr.err,
+		}
+	}
+	return Err{
+		parents: parents,
+		err:     err,
+	}
+}
+
+//Error impliments the error interface
+func (e Err) Error() string {
+	return fmt.Sprintf("VARS: %s: %s", strings.Join(e.parents, ": "), e.err.Error())
+}
+
+//IsNoRowsError returns true if the error is caused by no rows being effected
+func (e Err) IsNoRowsError() bool {
+	if e.err.Error() == ErrNoRowsInserted.Error() || e.err.Error() == ErrNoRowsUpdated.Error() {
+		return true
+	}
+	return false
+}
+
+//IsNoRowsError returns true if the error is caused by no rows being effected
+func IsNoRowsError(err error) bool {
+	if varsErr, ok := err.(Err); ok {
+		return varsErr.IsNoRowsError()
+	}
+	return false
+}

--- a/errors.go
+++ b/errors.go
@@ -22,6 +22,25 @@ var (
 	ErrGenericVars = errors.New("Something went wrong")
 )
 
+//Errs is a list of our errors making it easier to pass as a single paramenter and easier consumption
+type Errs []Err
+
+func (es Errs) Error() string {
+	var errStrings []string
+	for _, e := range es {
+		errStrings = append(errStrings, e.Error())
+	}
+	return strings.Join(errStrings, "\n")
+}
+
+func (es Errs) append(errT errType, parents ...string) {
+	es = append(es, newErr(errT, parents...))
+}
+
+func (es Errs) appendFromError(err error, parents ...string) {
+	es = append(es, newErrFromErr(err, parents...))
+}
+
 //Err is an error that occured inside the vars package
 type Err struct {
 	parents []string

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,0 +1,19 @@
+{
+	"comment": "",
+	"ignore": "test",
+	"package": [
+		{
+			"checksumSHA1": "uTUsjF7bymOuKvXbW2BpkK/w4Vg=",
+			"path": "github.com/lib/pq",
+			"revision": "2704adc878c21e1329f46f6e56a1c387d788ff94",
+			"revisionTime": "2017-03-24T20:46:54Z"
+		},
+		{
+			"checksumSHA1": "Gk3jTNQ5uGDUE0WMJFWcYz9PMps=",
+			"path": "github.com/lib/pq/oid",
+			"revision": "2704adc878c21e1329f46f6e56a1c387d788ff94",
+			"revisionTime": "2017-03-24T20:46:54Z"
+		}
+	],
+	"rootPath": "github.com/cbelk/vars"
+}


### PR DESCRIPTION
I also included Vendoring so that people who consume this package (or executables) will know which versions of packages this package uses (go build will use correct version)